### PR TITLE
Add quick mode

### DIFF
--- a/cluster-diagnosis/__main__.py
+++ b/cluster-diagnosis/__main__.py
@@ -22,6 +22,7 @@ import argparse
 import sysdumpcollector
 import os
 import time
+import distutils.util
 
 
 log = logging.getLogger(__name__)
@@ -45,20 +46,27 @@ if __name__ == "__main__":
         subparsers = parser.add_subparsers(dest='sysdump')
         subparsers.required = False
         parser_sysdump = subparsers.add_parser('sysdump',
-                                               help='collect logs and other '
-                                                    'useful information')
+                                               help='Collect logs and other '
+                                                    'useful information.')
         parser_sysdump.add_argument('--since',
                                     help='Only return logs newer than a '
                                          'relative duration like 5s, 2m, or'
-                                         ' 3h. Defaults to all logs.',
-                                    default='12h')
+                                         ' 3h. Defaults to 30m.',
+                                    default='30m')
         parser_sysdump.add_argument('--size-limit', type=int,
                                     help='size limit (bytes) for the '
-                                         'collected logs',
-                                    default=256 * 1024 * 1024)
+                                         'collected logs. '
+                                         'Defaults to 1048576 (1MB).',
+                                    default=1 * 1024 * 1024)
         parser_sysdump.add_argument('--output',
                                     help='Output filename without '
                                          ' .zip extension')
+        parser_sysdump.add_argument('--quick', type=distutils.util.strtobool,
+                                    default="false",
+                                    help='Enable quick mode. Logs and '
+                                         'cilium bugtool output will'
+                                         ' not be collected.'
+                                         'Defaults to "false".')
 
     args = parser.parse_args()
     try:
@@ -71,7 +79,8 @@ if __name__ == "__main__":
                 sysdump_dir_name,
                 args.since,
                 args.size_limit,
-                args.output)
+                args.output,
+                args.quick)
             sysdumpcollector.collect()
             sysdumpcollector.archive()
             sys.exit(0)

--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -37,11 +37,12 @@ class SysdumpCollector(object):
 
     def __init__(
             self,
-            sysdump_dir_name, since, size_limit, output):
+            sysdump_dir_name, since, size_limit, output, is_quick_mode):
         self.sysdump_dir_name = sysdump_dir_name
         self.since = since
         self.size_limit = size_limit
         self.output = output
+        self.is_quick_mode = is_quick_mode
 
     def collect_nodes_overview(self):
         nodes_overview_file_name = "nodes-{}.json".format(
@@ -319,6 +320,9 @@ class SysdumpCollector(object):
         log.info("collecting cilium daemonset yaml ...")
         self.collect_daemonset_yaml()
         log.info("collecting cilium configmap yaml ...")
+        if self.is_quick_mode:
+            return
+        # Time-consuming collect actions go here.
         self.collect_cilium_configmap()
         log.info("collecting cilium-bugtool output ...")
         self.collect_cilium_bugtool_output()


### PR DESCRIPTION
- This mode was added to reduce the sysdump time
for big clusters (> 50 nodes).

Signed-off-by: ashwinp <ashwin@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/30)
<!-- Reviewable:end -->
