### PR TITLE
Parallelize Log Collection

### DIFF
--- a/cluster-diagnosis/__main__.py
+++ b/cluster-diagnosis/__main__.py
@@ -84,8 +84,15 @@ if __name__ == "__main__":
             sysdumpcollector.collect()
             sysdumpcollector.archive()
             sys.exit(0)
-    except AttributeError:
-        pass
+    except AttributeError as e:
+        error_string = str(e)
+        # This change makes sure we *only* ignore attribute
+        # exceptions related to the args.sysdump workaround.
+        if (error_string.find('sysdump') != -1):
+            pass
+        else:
+            log.exception("Fatal error in collecting sysdump")
+            sys.exit(1)
     nodes = utils.get_nodes()
 
     k8s_check_grp = utils.ModuleCheckGroup("k8s")


### PR DESCRIPTION
1) Parallelize log collection of gops, cilium bugtool and cilium.
Standard python thread pool is used.

2) Remove unnecessary "-it" in kubectl exec. This will cause
corruption in STDOUT when running in parallel.

3) Add an extra exception log to clearly display the
non-user issue.

Test:
1) Performance test is conducted against the old implementation.
Substantial improvement has been observed.

2) Python3 compatibility test is broken before this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/36)
<!-- Reviewable:end -->
