### PR TITLE
Fix python3 incompatibility and k8s version regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cluster-diagnosis.zip
 
 # Editor
 .idea/
+
+# OS generated files
+.DS_Store

--- a/cluster-diagnosis/k8schecks.py
+++ b/cluster-diagnosis/k8schecks.py
@@ -31,7 +31,8 @@ def check_kube_apiserver_version_cb():
         True if successful, False otherwise.
     """
     p = re.compile(
-        r"^Server Version: version.Info{Major:\"(\d+)\", Minor:\"(\d+)\".*$")
+        r"^Server Version: version.Info{Major:\"(\d+)\", Minor:\"(\d+)\+?\".*$"
+        )
 
     cmd = "kubectl version"
     try:

--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -241,7 +241,7 @@ class SysdumpCollector(object):
         try:
             output = json.loads(subprocess.check_output(cmd, shell=True))
             data = {}
-            for key, value in output.get('data').iteritems():
+            for key, value in output.get('data').items():
                 data[key] = "XXXXX"
             output['data'] = data
             with open(


### PR DESCRIPTION
Fix: COV-2925

1) Python 3 replaced dict.iteritems() with dict.items()
Even though dict.items() in python 2 is inefficient, since our
dict is very small, it is fine.

2) When invoking kubectl version in GKE, the minor version returned
is Minor:"11+". Thus, add the optional \+? in the regex.

Tests:
1) Minikube
python cluster-diagnosis.zip [sysdump]
python3 cluster-diagnosis.zip [sysdump]
2) GKE
python cluster-diagnosis.zip --namespace cilium [sysdump]
python3 cluster-diagnosis.zip --namespace cilium [sysdump]

Signed-off-by: Rui Gu <rui@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/42)
<!-- Reviewable:end -->
