### PR TITLE
Argument name change and reuse pod namespace from pod_status

### DIFF
--- a/cluster-diagnosis/__main__.py
+++ b/cluster-diagnosis/__main__.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Cluster diagnosis '
                                                  'tool.')
 
-    parser.add_argument('--namespace', type=str, default='kube-system',
+    parser.add_argument('--cilium-ns', type=str, default='kube-system',
                         help="specify k8s namespace Cilium is running in")
     # Add an optional subparser for the sysdump command.
     # Optional subparsers are only supported in Python 3.3+.
@@ -85,7 +85,7 @@ if __name__ == "__main__":
                                          'Defaults to "false".')
 
     args = parser.parse_args()
-    namespace.name = args.namespace
+    namespace.cilium_ns = args.cilium_ns
     try:
         if args.sysdump:
             sysdump_dir_name = "./cilium-sysdump-{}"\

--- a/cluster-diagnosis/ciliumchecks.py
+++ b/cluster-diagnosis/ciliumchecks.py
@@ -37,7 +37,7 @@ def check_pod_running_cb(nodes):
     """
     ret_code = True
     pod_not_seen_on_nodes = nodes[:]
-    for name, ready_status, status, node_name in \
+    for name, ready_status, status, node_name, namespace in \
             utils.get_pods_summarized_status_iterator("k8s-app=cilium"):
         try:
             pod_not_seen_on_nodes.remove(node_name)
@@ -48,7 +48,7 @@ def check_pod_running_cb(nodes):
                       " {} and status {}".format(
                           name, node_name, ready_status, status))
             # Check the log for common errors.
-            cmd = "kubectl logs -n {} {}".format(namespace.name, name)
+            cmd = "kubectl logs -n {} {}".format(namespace, name)
             output = ""
             try:
                 encoded_output = subprocess.check_output(cmd, shell=True)
@@ -151,12 +151,12 @@ def check_drop_notifications_enabled_cb():
         True if successful, False otherwise.
     """
     ret_code = True
-    for name, ready_status, status, node_name in \
+    for name, ready_status, status, node_name, namespace in \
             utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
         cmd = ("kubectl exec -it {}"
                " -n {} cilium config "
                "| grep DropNotification "
-               "| awk '{{print $2}}'").format(name, namespace.name)
+               "| awk '{{print $2}}'").format(name, namespace)
         output = ""
         try:
             encoded_output = subprocess.check_output(cmd, shell=True)
@@ -195,12 +195,12 @@ def check_trace_notifications_enabled_cb():
         True if successful, False otherwise.
     """
     ret_code = True
-    for name, ready_status, status, node_name in \
+    for name, ready_status, status, node_name, namespace in \
             utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
         cmd = ("kubectl exec -it {}"
                " -n {} cilium config "
                "| grep TraceNotification "
-               "| awk '{{print $2}}'").format(name, namespace.name)
+               "| awk '{{print $2}}'").format(name, namespace)
         output = ""
         try:
             encoded_output = subprocess.check_output(cmd, shell=True)
@@ -239,12 +239,12 @@ def check_cilium_version_cb():
         True if successful, False otherwise.
     """
     ret_code = True
-    for name, ready_status, status, node_name in \
+    for name, ready_status, status, node_name, namespace in \
             utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
         cmd = ("kubectl describe pod {}"
                " -n {} | grep \"Image:.*docker.io/cilium/cilium\" | "
                "awk '{{print $2}}' "
-               "| awk -F ':' '{{print $2}}'").format(name, namespace.name)
+               "| awk -F ':' '{{print $2}}'").format(name, namespace)
         output = ""
         try:
             encoded_output = subprocess.check_output(cmd, shell=True)

--- a/cluster-diagnosis/k8schecks.py
+++ b/cluster-diagnosis/k8schecks.py
@@ -76,10 +76,10 @@ def check_rbac_cb():
         True if successful, False otherwise.
     """
     ret_code = True
-    for name, ready_status, status, node_name in \
+    for name, ready_status, status, node_name, namespace in \
             utils.get_pods_status_iterator_by_labels(
                 "component=kube-apiserver", [], False):
-        cmd = "kubectl describe pod {} -n {}".format(name, namespace.name)
+        cmd = "kubectl describe pod {} -n {}".format(name, namespace)
         try:
             encoded_output = subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError as exc:

--- a/cluster-diagnosis/namespace.py
+++ b/cluster-diagnosis/namespace.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name = "kube-system"
+cilium_ns = "kube-system"

--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -109,7 +109,7 @@ class SysdumpCollector(object):
         command = "kubectl logs {} --timestamps=true --since={} " \
             "--limit-bytes={} -n {} {} > {}/{}.log"
         cmd = command.format(
-            "", self.since, self.size_limit, namespace.name, podstatus[0],
+            "", self.since, self.size_limit, podstatus[4], podstatus[0],
             self.sysdump_dir_name, log_file_name)
         try:
             subprocess.check_output(cmd, shell=True)
@@ -123,7 +123,7 @@ class SysdumpCollector(object):
         # Previous containers
         log_file_name_previous = "{0}-previous".format(log_file_name)
         cmd = command.format(
-            "--previous", self.since, self.size_limit, namespace.name,
+            "--previous", self.since, self.size_limit, podstatus[4],
             podstatus[0],
             self.sysdump_dir_name, log_file_name_previous)
         try:
@@ -160,7 +160,7 @@ class SysdumpCollector(object):
                 type_of_stat)
             cmd = "kubectl exec -n {} {} -- " \
                   "/bin/gops {} 1 > {}/{}".format(
-                      namespace.name,
+                      podstatus[4],
                       podstatus[0],
                       type_of_stat,
                       self.sysdump_dir_name,
@@ -206,7 +206,7 @@ class SysdumpCollector(object):
         daemonset_file_name = "cilium-ds-{}.yaml".format(
             utils.get_current_time())
         cmd = "kubectl get ds cilium -n {} -oyaml > {}/{}".format(
-            namespace.name, self.sysdump_dir_name, daemonset_file_name)
+            namespace.cilium_ns, self.sysdump_dir_name, daemonset_file_name)
         try:
             subprocess.check_output(cmd, shell=True)
         except subprocess.CalledProcessError as exc:
@@ -221,7 +221,7 @@ class SysdumpCollector(object):
         configmap_file_name = "cilium-configmap-{}.yaml".format(
             utils.get_current_time())
         cmd = "kubectl get configmap cilium-config -n {} -oyaml " \
-              "> {}/{}".format(namespace.name,
+              "> {}/{}".format(namespace.cilium_ns,
                                self.sysdump_dir_name, configmap_file_name)
         try:
             subprocess.check_output(cmd, shell=True)
@@ -237,7 +237,7 @@ class SysdumpCollector(object):
         secret_file_name = "cilium-etcd-secrets-{}.json".format(
             utils.get_current_time())
         cmd = "kubectl get secret cilium-etcd-secrets -n {} -o json".format(
-            namespace.name)
+            namespace.cilium_ns)
         try:
             output = json.loads(subprocess.check_output(cmd, shell=True))
             data = {}
@@ -269,7 +269,7 @@ class SysdumpCollector(object):
         bugtool_output_file_name = "bugtool-{}-{}.tar".format(
             podstatus[0], utils.get_current_time())
         cmd = "kubectl exec -n {} {} cilium-bugtool".format(
-            namespace.name, podstatus[0])
+            podstatus[4], podstatus[0])
         try:
             encoded_output = subprocess.check_output(cmd.split(), shell=False)
         except subprocess.CalledProcessError as exc:
@@ -292,7 +292,7 @@ class SysdumpCollector(object):
                     " file name".format(exc))
 
             cmd = "kubectl cp {}/{}:{} ./{}/{}".format(
-                namespace.name, podstatus[0], output_file_name,
+                podstatus[4], podstatus[0], output_file_name,
                 self.sysdump_dir_name,
                 bugtool_output_file_name)
             try:


### PR DESCRIPTION
1) Change input argument namespace to cilium_ns to be more
specific. This leaves the space for isovalent
namespace.

2) Previously, we first obtain pod status by running
"kubectl get pods --all-namespaces -o=wide -l LABEL".
Then, we run kubectl exec to obtain logs. When running
kubectl exec, we use the input argument to indicate
the namespace. This is unnecessary. This change obtain
namespace information when getting the pod information
and reuse this. This reduce the dependency on the input
namespace argument.

Tests:
1) Minikube
python[2|3] cluster-diagnosis.zip [--cilium-ns kube-system] [sysdump]
2) GKE
python[2|3] cluster-diagnosis.zip [--cilium-ns cilium] [sysdump]

Also checked the individual file size for the dumped files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/43)
<!-- Reviewable:end -->
