### PR TITLE
Automatically infer cilium's namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ cluster-diagnosis.zip
 
 # OS generated files
 .DS_Store
+
+# Python bytecode
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,12 @@ check: check-tools
 check-tools:
 	command -v pycodestyle >/dev/null 2>&1 || { echo "Package pycodestyle not installed. Aborting." >&2; exit 1; }
 
-build: clean check
+build: syntax-check clean check
 	cd cluster-diagnosis/ && zip -r ../cluster-diagnosis.zip *
 
+syntax-check:
+	./python-syntax-check.sh
+
 clean:
+	rm -rf ./cluster-diagnosis/*.pyc ./cluster-diagnosis/__pycache__
 	rm -rf ./cluster-diagnosis.zip

--- a/cluster-diagnosis/__main__.py
+++ b/cluster-diagnosis/__main__.py
@@ -85,7 +85,15 @@ if __name__ == "__main__":
                                          'Defaults to "false".')
 
     args = parser.parse_args()
-    namespace.cilium_ns = args.cilium_ns
+    # Automatically infer Cilium's namespace using Cilium daemonset's namespace
+    # Fall back to the specified namespace in the input argument if it fails.
+    try:
+        status = utils.get_resource_status(
+            "daemonset", full_name="cilium")
+        namespace.cilium_ns = status[0]
+    except RuntimeError as e:
+        namespace.cilium_ns = args.cilium_ns
+        pass
     try:
         if args.sysdump:
             sysdump_dir_name = "./cilium-sysdump-{}"\

--- a/python-syntax-check.sh
+++ b/python-syntax-check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+SCRIPTS_DIR="$(dirname ${0})"
+
+echo "Syntax check for all python code..."
+while read f; do
+    if ! python -m py_compile "${f}"; then
+        echo "Error: Please check ${f} for Python 2 syntax errors"
+        exit 1
+    fi
+    if ! python3 -m py_compile "${f}"; then
+        echo "Error: Please check ${f} for Python 3 syntax errors"
+        exit 1
+    fi
+done < <(find "${SCRIPTS_DIR}/cluster-diagnosis" -name "*.py" -prune -type f)


### PR DESCRIPTION
1) Automatically infer cilium's namespace using cilium daemonset's
namespace. If it fails, fall back to the namespace specified in
the input argument.

2) Add python syntax check during build process.

Tests:
Minikube:
python[2|3] cluster-diagnosis.zip [sydump]
GKE:
python[2|3] cluster-diagnosis.zip [sysdump]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/44)
<!-- Reviewable:end -->
