### PR TITLE
Fix namespace inference

### DIFF
--- a/cluster-diagnosis/__main__.py
+++ b/cluster-diagnosis/__main__.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     # Fall back to the specified namespace in the input argument if it fails.
     try:
         status = utils.get_resource_status(
-            "daemonset", full_name="cilium", label="k8s-app=cilium")
+            "pod", full_name="", label="k8s-app=cilium")
         namespace.cilium_ns = status[0]
     except RuntimeError as e:
         namespace.cilium_ns = args.cilium_ns


### PR DESCRIPTION
The cilium namespace was infered by detecting the cilium
daemonset with label k8s-app=cilium. However, prior to cilium 1.4,
we don't have that label for the daemonset.
This change use cilium pod with label k8s-app=cilium to detect
cilium daemonset namespace.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/48)
<!-- Reviewable:end -->
