### PR TITLE
Fix JSON load for python 3.5

### DIFF
--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -253,7 +253,8 @@ class SysdumpCollector(object):
         cmd = "kubectl get secret cilium-etcd-secrets -n {} -o json".format(
             namespace.cilium_ns)
         try:
-            output = json.loads(subprocess.check_output(cmd, shell=True))
+            output = json.loads(
+                subprocess.check_output(cmd, shell=True).decode("utf-8"))
             data = {}
             for key, value in output.get('data').items():
                 data[key] = "XXXXX"


### PR DESCRIPTION
Before python 3.6, json.load() only takes string. Thus,
cluster-diagnosis is broken in python 3.5.
This change converts bytes to string before loading it to json.