### PR TITLE
Fix Cilium version parsing bug

### DIFF
--- a/cluster-diagnosis/ciliumchecks.py
+++ b/cluster-diagnosis/ciliumchecks.py
@@ -241,10 +241,11 @@ def check_cilium_version_cb():
     ret_code = True
     for name, ready_status, status, node_name, namespace in \
             utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
-        cmd = ("kubectl describe pod {}"
-               " -n {} | grep \"Image:.*docker.io/cilium/cilium\" | "
-               "awk '{{print $2}}' "
-               "| awk -F ':' '{{print $2}}'").format(name, namespace)
+        cmd = ("kubectl get pod {}"
+               " -n {} -o jsonpath='{{.spec.containers"
+               "[?(@.command[]==\"cilium-agent\")].image}}' | "
+               "awk -F \":\" '{{print $2}}'")\
+            .format(name, namespace)
         output = ""
         try:
             encoded_output = subprocess.check_output(cmd, shell=True)


### PR DESCRIPTION
- There are now two images, one for cilium-agent,
and the other for init-container.

Signed-off-by: ashwinp <ashwin@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/52)
<!-- Reviewable:end -->
