### PR TITLE
GH-55 Fix cluster-diagnosis for k8s 1.13

### DIFF
--- a/cluster-diagnosis/ciliumchecks.py
+++ b/cluster-diagnosis/ciliumchecks.py
@@ -43,7 +43,7 @@ def check_pod_running_cb(nodes):
             pod_not_seen_on_nodes.remove(node_name)
         except ValueError:
             pass
-        if status != utils.STATUS_RUNNING or ready_status != "1/1":
+        if status != utils.STATUS_RUNNING or ready_status != "true":
             log.error("pod {} running on {} has ready status"
                       " {} and status {}".format(
                           name, node_name, ready_status, status))
@@ -84,7 +84,7 @@ def check_pod_running_cb(nodes):
                 log.error("Hint: BPF requirements have not been met. Check"
                           " Cilium logs for more information.")
         else:
-            log.info("pod {} running on {} has {} pods ready"
+            log.info("pod {} running on {} has pod ready status {}"
                      " and status {}".format(
                          name,
                          node_name,

--- a/cluster-diagnosis/utils.py
+++ b/cluster-diagnosis/utils.py
@@ -315,11 +315,15 @@ def get_pods_status_iterator_by_labels(label_selector, host_ip_filter,
     Returns:
         An object of type PodStatus.
     """
-    cmd = ("kubectl get pods --all-namespaces -o wide --selector={}"
-           "| awk 'BEGIN{{offset=0}}"
-           "/NOMINATED/{{offset=1}}"
-           "!/NAME/{{print $2 \" \" $3 \" \" $4 \" \" $(NF-offset) \" \" $1}}'"
-           ).format(label_selector)
+    # TODO: Handle the case of a pod w/ multiple containers.
+    # Right now, we pick the status of the first container in the pod.
+    cmd = ("kubectl get pods --all-namespaces -o wide"
+           " --selector={} -o=jsonpath='{{range .items[*]}}"
+           "{{@.metadata.name}}{{\" \"}}"
+           "{{@.status.containerStatuses[0].ready}}{{\" \"}}"
+           "{{@.status.phase}}{{\" \"}}"
+           "{{@.spec.nodeName}}{{\" \"}}"
+           "{{@.metadata.namespace}}{{\"\\n\"}}'").format(label_selector)
     try:
         encoded_output = subprocess.check_output(cmd, shell=True)
     except subprocess.CalledProcessError as exc:
@@ -335,42 +339,12 @@ def get_pods_status_iterator_by_labels(label_selector, host_ip_filter,
                       "{} are running on the cluster".format(
                         label_selector))
         return
-    # kubectl field selector supports listing pods based on a particular
-    # field. However, it doesn't support hostIP field in 1.9.6. Also,
-    # it doesn't support set-based filtering. As a result, we will use
-    # grep based filtering for now. We might want to switch to this
-    # feature in the future. The following filter can be extended by
-    # modifying the following kubectl custom-columns and the associated
-    # grep command.
-    host_ip_filter_cmd = "kubectl get pods --no-headers " \
-        "-o=custom-columns=NAME:.metadata.name," \
-        "HOSTIP:.status.hostIP --all-namespaces | grep -E \"{}\" | " \
-        "awk '{{print $1}}'"
-    host_ip_filter_cmd = host_ip_filter_cmd.format(
-        "|".join(map(str, host_ip_filter)))
-    try:
-        filter_output = subprocess.check_output(
-            host_ip_filter_cmd, shell=True)
-    except subprocess.CalledProcessError as exc:
-        log.error("command to list filtered pods has "
-                  "failed. error code: "
-                  "{} {}".format(exc.returncode, exc.output))
-    filter_output = filter_output.decode()
-    if filter_output == "":
-        if must_exist:
-            log.error("No output because all the pods were filtered "
-                      "out by the node ip filter {}.".format(
-                        host_ip_filter))
-        return
-    filtered_pod_list = filter_output.splitlines()
 
     for line in output.splitlines():
         # Example line:
         # name-blah-sr64c 0/1 CrashLoopBackOff
         # ip-172-0-33-255.us-west-2.compute.internal kube-system
         split_line = line.split(' ')
-        if split_line[0] not in filtered_pod_list:
-            continue
         yield PodStatus(name=split_line[0],
                         ready_status=split_line[1],
                         status=split_line[2],


### PR DESCRIPTION
- Use json parsing to extract fields
instead of awk.
- Remove filtering code that doesn't work on all k8s versions.

Signed-off-by: ashwinp <ashwin@covalent.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/56)
<!-- Reviewable:end -->
