### PR TITLE
Fix thread pool size

### DIFF
--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -306,7 +306,7 @@ class SysdumpCollector(object):
                 secret_file_name))
 
     def collect_cilium_bugtool_output(self, label_selector, node_ip_filter):
-        pool = ThreadPool(multiprocessing.cpu_count() - 1)
+        pool = ThreadPool(multiprocessing.cpu_count())
         pool.map(
             self.collect_cilium_bugtool_output_per_pod,
             utils.get_pods_status_iterator_by_labels(


### PR DESCRIPTION
Previously, the process pool size was set to number of cores minus one.
Thus, if running on a single core machine, the size will be 0.
This commit sets the thread pool size equals to the number of cores
to fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/64)
<!-- Reviewable:end -->
