### PR TITLE
add flag to specify cilium pod labels

### DIFF
--- a/cluster-diagnosis/ciliumchecks.py
+++ b/cluster-diagnosis/ciliumchecks.py
@@ -25,7 +25,7 @@ MINIMUM_SUPPORTED_CILIUM_VERSION_MINOR = 0
 MINIMUM_SUPPORTED_CILIUM_VERSION_PATCH = 0
 
 
-def check_pod_running_cb(nodes):
+def check_pod_running_cb(nodes, cilium_labels):
     """Checks whether the Cilium container is running on all the nodes.
 
     Args:
@@ -38,7 +38,7 @@ def check_pod_running_cb(nodes):
     ret_code = True
     pod_not_seen_on_nodes = nodes[:]
     for name, ready_status, status, node_name, namespace in \
-            utils.get_pods_summarized_status_iterator("k8s-app=cilium"):
+            utils.get_pods_summarized_status_iterator(cilium_labels):
         try:
             pod_not_seen_on_nodes.remove(node_name)
         except ValueError:
@@ -101,7 +101,7 @@ def check_pod_running_cb(nodes):
     return ret_code
 
 
-def check_access_log_config_cb():
+def check_access_log_config_cb(cilium_labels):
     """Checks cilium access log parameter.
 
     Args:
@@ -112,7 +112,7 @@ def check_access_log_config_cb():
     """
     ret_code = True
     for name, ready_status, status, node_name in \
-            utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
+            utils.get_pods_status_iterator_by_labels(cilium_labels, []):
         # TODO: Add volume checks.
         config = utils.get_pod_config(name)
         if not config:
@@ -141,7 +141,7 @@ def check_access_log_config_cb():
     return ret_code
 
 
-def check_drop_notifications_enabled_cb():
+def check_drop_notifications_enabled_cb(cilium_labels):
     """Checks whether DropNotification is enabled
 
     Args:
@@ -152,7 +152,7 @@ def check_drop_notifications_enabled_cb():
     """
     ret_code = True
     for name, ready_status, status, node_name, namespace in \
-            utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
+            utils.get_pods_status_iterator_by_labels(cilium_labels, []):
         cmd = ("kubectl exec -it {}"
                " -n {} cilium config "
                "| grep DropNotification "
@@ -185,7 +185,7 @@ def check_drop_notifications_enabled_cb():
     return ret_code
 
 
-def check_trace_notifications_enabled_cb():
+def check_trace_notifications_enabled_cb(cilium_labels):
     """Checks whether TraceNotification is enabled
 
     Args:
@@ -196,7 +196,7 @@ def check_trace_notifications_enabled_cb():
     """
     ret_code = True
     for name, ready_status, status, node_name, namespace in \
-            utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
+            utils.get_pods_status_iterator_by_labels(cilium_labels, []):
         cmd = ("kubectl exec -it {}"
                " -n {} cilium config "
                "| grep TraceNotification "
@@ -229,7 +229,7 @@ def check_trace_notifications_enabled_cb():
     return ret_code
 
 
-def check_cilium_version_cb():
+def check_cilium_version_cb(cilium_labels):
     """Checks whether cilium version is >= minimum supported version.
 
     Args:
@@ -240,7 +240,7 @@ def check_cilium_version_cb():
     """
     ret_code = True
     for name, ready_status, status, node_name, namespace in \
-            utils.get_pods_status_iterator_by_labels("k8s-app=cilium", []):
+            utils.get_pods_status_iterator_by_labels(cilium_labels, []):
         cmd = ("kubectl get pod {}"
                " -n {} -o jsonpath='{{.spec.containers"
                "[?(@.command[]==\"cilium-agent\")].image}}' | "

--- a/cluster-diagnosis/sysdumpcollector.py
+++ b/cluster-diagnosis/sysdumpcollector.py
@@ -41,12 +41,14 @@ class SysdumpCollector(object):
 
     def __init__(
             self,
-            sysdump_dir_name, since, size_limit, output, is_quick_mode):
+            sysdump_dir_name, since, size_limit, output, is_quick_mode,
+            cilium_labels):
         self.sysdump_dir_name = sysdump_dir_name
         self.since = since
         self.size_limit = size_limit
         self.output = output
         self.is_quick_mode = is_quick_mode
+        self.cilium_labels = cilium_labels
 
     def collect_nodes_overview(self):
         nodes_overview_file_name = "nodes-{}.json".format(
@@ -423,7 +425,7 @@ class SysdumpCollector(object):
         log.info("collecting services overview ...")
         self.collect_services_overview()
         log.info("collecting cilium gops stats ...")
-        self.collect_gops_stats("k8s-app=cilium", node_ip_filter)
+        self.collect_gops_stats(self.cilium_labels, node_ip_filter)
         log.info("collecting kubernetes network policy ...")
         self.collect_netpol()
         log.info("collecting cilium network policy ...")
@@ -440,9 +442,9 @@ class SysdumpCollector(object):
             return
         # Time-consuming collect actions go here.
         log.info("collecting cilium-bugtool output ...")
-        self.collect_cilium_bugtool_output("k8s-app=cilium", node_ip_filter)
+        self.collect_cilium_bugtool_output(self.cilium_labels, node_ip_filter)
         log.info("collecting cilium logs ...")
-        self.collect_logs("k8s-app=cilium", node_ip_filter)
+        self.collect_logs(self.cilium_labels, node_ip_filter)
         self.collect_logs("io.cilium/app=operator", [])
 
     def archive(self):


### PR DESCRIPTION
Remove the hardcoded "k8s-app=cilium" label used to get all Cilium pods, and instead,
use a value which can be provided by the user. The default is still "k8s-app=cilium".

Example:
```
python cluster-diagnosis.zip sysdump --cilium-labels=k8s-app=cilium,kubernetes.io/cluster-service=true
```

Signed-off by: Ian Vernon <ian@cilium.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/65)
<!-- Reviewable:end -->
