### PR TITLE
Make cilium-labels option available globally

### DIFF
--- a/cluster-diagnosis/__main__.py
+++ b/cluster-diagnosis/__main__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 Authors of Cilium
+# Copyright 2017-2019 Authors of Cilium
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,10 @@ if __name__ == "__main__":
 
     parser.add_argument('--cilium-ns', type=str, default='kube-system',
                         help="specify k8s namespace Cilium is running in")
+    parser.add_argument('--cilium-labels',
+                        help='Labels of cilium pods running in '
+                        'the cluster',
+                        default="k8s-app=cilium")
     # Add an optional subparser for the sysdump command.
     # Optional subparsers are only supported in Python 3.3+.
     # Python 2.7 optional subparsers implementation has bugs,
@@ -83,10 +87,6 @@ if __name__ == "__main__":
                                          'cilium bugtool output will'
                                          ' not be collected.'
                                          'Defaults to "false".')
-        parser_sysdump.add_argument('--cilium-labels',
-                                    help='Labels of cilium pods running in '
-                                         'the cluster',
-                                    default="k8s-app=cilium")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
It doesn't make sense to restrict this option to sysdump, and having it
restricted to sysdump causes issues like #69. Fix it by making it a
general option in the standard args parser.

Fixes: #69

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cilium/cluster-diagnosis/70)
<!-- Reviewable:end -->
